### PR TITLE
Created API routes for the employee facility report

### DIFF
--- a/express-server/app.js
+++ b/express-server/app.js
@@ -3,8 +3,9 @@ import cors from 'cors';
 import dotenv from 'dotenv';
 import express from 'express';
 
-import { requireHR, userAuth } from './middlewares/AuthMiddlewares.js';
+import { requireEmployee, requireHR, userAuth } from './middlewares/AuthMiddlewares.js';
 import errorHandler from './middlewares/ErrorHandler.js';
+import employeeFacilityReportRouter from './routers/EmployeeFacilityReportRouter.js';
 import hrOnboardingRouter from './routers/HrOnboardingRouter.js';
 import hrTokenRouter from './routers/HrTokenRouter.js';
 import userRouter from './routers/UserRouter.js';
@@ -31,6 +32,9 @@ app.use('/api/user', userRouter);
 // HR specific routes
 app.use('/api/hr/token', userAuth, requireHR, hrTokenRouter);
 app.use('/api/hr/onboarding', userAuth, requireHR, hrOnboardingRouter);
+
+// Employee specific routes
+app.use('/api/employee/facilityReport', userAuth, requireEmployee, employeeFacilityReportRouter);
 
 // Fallback route
 app.get('*', (req, res) => {

--- a/express-server/controllers/EmployeeFacilityReportController.js
+++ b/express-server/controllers/EmployeeFacilityReportController.js
@@ -113,6 +113,37 @@ export const updateFacilityReport = async (req, res) => {
 };
 
 /**
+ * @desc    Close the current facility report
+ * @route   PATCH /api/employee/facilityReport/:facilityReportId/close
+ * @access  Employee only
+ */
+export const closeFacilityReport = async (req, res) => {
+  try {
+    const { facilityReportId } = req.params;
+    const { id: userId } = req.user;
+
+    const findEmployeeByUserId = await Employee.findOne({
+      userId,
+    });
+    const { _id: employeeId } = findEmployeeByUserId;
+    const facilityReport = await FacilityReport.findById(facilityReportId);
+    if (employeeId.toString() !== facilityReport.employeeId.toString()) {
+      return res.status(403).json({
+        message: 'This employee did NOT create this facility report! Hence, they CANNOT close it!',
+      });
+    }
+
+    await FacilityReport.findByIdAndUpdate(facilityReportId, {
+      status: 'Closed',
+    });
+
+    res.status(200).json({ message: 'Successfully closed the facility report' });
+  } catch (error) {
+    res.status(500).json({ message: 'Failed to close the facility report!', error });
+  }
+};
+
+/**
  * @desc    Delete the facility report
  * @route   DELETE /api/employee/facilityReport/:facilityReportId/delete
  * @access  Employee only

--- a/express-server/controllers/EmployeeFacilityReportController.js
+++ b/express-server/controllers/EmployeeFacilityReportController.js
@@ -1,0 +1,233 @@
+import Employee from '../models/Employee.js';
+import FacilityReport from '../models/FacilityReport.js';
+import Housing from '../models/Housing.js';
+
+/**
+ * @desc    Find all facility reports submitted by the current user for a specific house
+ * @route   GET /api/employee/facilityReport/house/:houseId
+ * @access  Employee only
+ */
+export const getCurrentUserFacilityReportsByHouseId = async (req, res) => {
+  try {
+    const { houseId } = req.params;
+    const { id: userId } = req.user;
+
+    const findEmployeeByUserId = await Employee.findOne({
+      userId,
+    });
+    const { _id: employeeId } = findEmployeeByUserId;
+
+    const facilityReports = await FacilityReport.find({
+      houseId,
+      employeeId,
+    });
+
+    res.status(200).json(facilityReports);
+  } catch (error) {
+    res.status(500).json({ message: 'Failed to find the facility reports', error });
+  }
+};
+
+/**
+ * @desc    Create a facility report for a specific house
+ * @route   POST /api/employee/facilityReport/house/:houseId/create
+ * @access  Employee only
+ */
+export const createFacilityReport = async (req, res) => {
+  try {
+    const { houseId } = req.params;
+    const { title, description } = req.body;
+    const { id: userId } = req.user;
+
+    const findEmployeeByUserId = await Employee.findOne({
+      userId,
+    });
+    const { _id: employeeId } = findEmployeeByUserId;
+    const findHouseById = await Housing.findById(houseId);
+    if (!findHouseById.residents.includes(employeeId)) {
+      return res.status(403).json({
+        message:
+          'Employee does NOT reside in this house. Hence, they CANNOT write a facility report of this house!',
+      });
+    }
+
+    const newFacilityReport = new FacilityReport({
+      employeeId,
+      houseId,
+      title,
+      description,
+      comments: [],
+    });
+    await newFacilityReport.save();
+
+    res.status(201).json({
+      message: 'Facility Report successfully created!',
+      facility_report: newFacilityReport,
+    });
+  } catch (error) {
+    res.status(500).json({ message: 'Failed to create a Facility Report!', error });
+  }
+};
+
+/**
+ * @desc    Update the facility report
+ * @route   PUT /api/employee/facilityReport/:facilityReportId/update
+ * @access  Employee only
+ */
+export const updateFacilityReport = async (req, res) => {
+  try {
+    const { facilityReportId } = req.params;
+    const { title, description } = req.body;
+    const { id: userId } = req.user;
+
+    const findEmployeeByUserId = await Employee.findOne({
+      userId,
+    });
+    const { _id: employeeId } = findEmployeeByUserId;
+    const originalFacilityReport = await FacilityReport.findById(facilityReportId);
+    if (employeeId.toString() !== originalFacilityReport.employeeId.toString()) {
+      return res.status(403).json({
+        message: 'This employee did NOT create this facility report! Hence, they CANNOT edit it!',
+      });
+    }
+
+    const updatedFacilityReport = await FacilityReport.findByIdAndUpdate(
+      facilityReportId,
+      {
+        title,
+        description,
+      },
+      {
+        new: true,
+      }
+    );
+
+    res.status(200).json({
+      message: 'Facility Report successfully updated',
+      originalFacilityReport,
+      updatedFacilityReport,
+    });
+  } catch (error) {
+    res.status(500).json({ message: 'Failed to update the Facility Report!', error });
+  }
+};
+
+/**
+ * @desc    Delete the facility report
+ * @route   DELETE /api/employee/facilityReport/:facilityReportId/delete
+ * @access  Employee only
+ */
+export const deleteFacilityReport = async (req, res) => {
+  try {
+    const { facilityReportId } = req.params;
+    const { id: userId } = req.user;
+
+    const findEmployeeByUserId = await Employee.findOne({
+      userId,
+    });
+    const { _id: employeeId } = findEmployeeByUserId;
+    const facilityReport = await FacilityReport.findById(facilityReportId);
+    if (employeeId.toString() !== facilityReport.employeeId.toString()) {
+      return res.status(403).json({
+        message: 'This employee did NOT create this facility report! Hence, they CANNOT delete it!',
+      });
+    }
+
+    await FacilityReport.findByIdAndDelete(facilityReportId);
+
+    res.status(200).json({ message: 'Facility Report successfully deleted', facilityReport });
+  } catch (error) {
+    res.status(500).json({ message: 'Failed to delete the Facility Report!', error });
+  }
+};
+
+/**
+ * @desc    Comment on their facility report
+ * @route   POST /api/employee/facilityReport/:facilityReportId/comments
+ * @access  Employee only
+ */
+export const addCommentOnFacilityReport = async (req, res) => {
+  try {
+    const { facilityReportId } = req.params;
+    const { id: userId } = req.user;
+
+    const findEmployeeByUserId = await Employee.findOne({
+      userId,
+    });
+    const { _id: employeeId } = findEmployeeByUserId;
+    const facilityReport = await FacilityReport.findById(facilityReportId);
+    if (employeeId.toString() !== facilityReport.employeeId.toString()) {
+      return res.status(403).json({
+        message:
+          'This employee did NOT create this facility report! Hence, they CANNOT view the report and as a result, they should NOT be able to comment on it!',
+      });
+    }
+
+    const { commentDescription } = req.body;
+    const newComment = {
+      createdBy: employeeId,
+      description: commentDescription,
+      timestamp: new Date(),
+    };
+    const newCommentList = [...facilityReport.comments];
+    newCommentList.push(newComment);
+    await FacilityReport.findByIdAndUpdate(facilityReportId, {
+      status: 'In Progress',
+      comments: newCommentList,
+    });
+
+    res.status(200).json({
+      message: 'Successfully added a comment on the Facility Report!',
+      prevCommentList: facilityReport.comments,
+      newCommentList,
+    });
+  } catch (error) {
+    res.status(500).json({ message: 'Failed to add a comment on the Facility Report!', error });
+  }
+};
+
+/**
+ * @desc    Update comment on the facility report
+ * @route   PUT /api/employee/facilityReport/:facilityReportId/comments/:commentId
+ * @access  Employee only
+ */
+export const updateCommentOnFacilityReport = async (req, res) => {
+  try {
+    const { facilityReportId } = req.params;
+    const { id: userId } = req.user;
+
+    const findEmployeeByUserId = await Employee.findOne({
+      userId,
+    });
+    const { _id: employeeId } = findEmployeeByUserId;
+    const facilityReport = await FacilityReport.findById(facilityReportId);
+    if (employeeId.toString() !== facilityReport.employeeId.toString()) {
+      return res.status(403).json({
+        message:
+          'This employee did NOT create this facility report! Hence, they CANNOT view the report and as a result, they should NOT be able to update any comments there!',
+      });
+    }
+
+    const newCommentList = [...facilityReport.comments];
+    const { commentId } = req.params;
+    const commentToUpdate = newCommentList.find((comment) => {
+      return comment._id.toString() === commentId;
+    });
+    const previousCommentDescription = commentToUpdate.description;
+    const { commentDescription } = req.body;
+    if (commentToUpdate) {
+      commentToUpdate.description = commentDescription;
+    }
+    await FacilityReport.findByIdAndUpdate(facilityReportId, {
+      comments: newCommentList,
+    });
+
+    res.status(200).json({
+      message: 'Successfully updated the comment',
+      prevComment: previousCommentDescription,
+      updatedComment: commentToUpdate.description,
+    });
+  } catch (error) {
+    res.status(500).json({ message: 'Failed to update the comment', error });
+  }
+};

--- a/express-server/controllers/EmployeeFacilityReportController.js
+++ b/express-server/controllers/EmployeeFacilityReportController.js
@@ -245,9 +245,20 @@ export const updateCommentOnFacilityReport = async (req, res) => {
       return comment._id.toString() === commentId;
     });
     const previousCommentDescription = commentToUpdate.description;
-    const { commentDescription } = req.body;
+    const { updatedCommentDescription } = req.body;
+    // Check if this comment exists
     if (commentToUpdate) {
-      commentToUpdate.description = commentDescription;
+      // Check if this is the current employee's comment
+      // If so, it will update the comment's description
+      if (employeeId.toString() === commentToUpdate.createdBy.toString()) {
+        commentToUpdate.description = updatedCommentDescription;
+      }
+      // Otherwise, it will throw a forbidden error!
+      else {
+        return res.status(403).json({
+          message: 'This employee did NOT create this comment! Hence, they CANNOT edit it!',
+        });
+      }
     }
     await FacilityReport.findByIdAndUpdate(facilityReportId, {
       comments: newCommentList,

--- a/express-server/routers/EmployeeFacilityReportRouter.js
+++ b/express-server/routers/EmployeeFacilityReportRouter.js
@@ -2,6 +2,7 @@ import express from 'express';
 
 import {
   addCommentOnFacilityReport,
+  closeFacilityReport,
   createFacilityReport,
   deleteFacilityReport,
   getCurrentUserFacilityReportsByHouseId,
@@ -28,6 +29,12 @@ router.post('/house/:houseId/create', createFacilityReport);
  * @route   PUT /api/employee/facilityReport/:facilityReportId/update
  */
 router.put('/:facilityReportId/update', updateFacilityReport);
+
+/**
+ * @desc    Close the facility report
+ * @route   PATCH /api/employee/facilityReport/:facilityReportId/close
+ */
+router.patch('/:facilityReportId/close', closeFacilityReport);
 
 /**
  * @desc    Delete the facility report

--- a/express-server/routers/EmployeeFacilityReportRouter.js
+++ b/express-server/routers/EmployeeFacilityReportRouter.js
@@ -1,0 +1,50 @@
+import express from 'express';
+
+import {
+  addCommentOnFacilityReport,
+  createFacilityReport,
+  deleteFacilityReport,
+  getCurrentUserFacilityReportsByHouseId,
+  updateCommentOnFacilityReport,
+  updateFacilityReport,
+} from '../controllers/EmployeeFacilityReportController.js';
+
+const router = express.Router();
+
+/**
+ * @desc    Get all facility reports submitted by the current user for a specific house
+ * @route   GET /api/employee/facilityReport/house/:houseId
+ */
+router.get('/house/:houseId', getCurrentUserFacilityReportsByHouseId);
+
+/**
+ * @desc    Create a facility report for a specific house
+ * @route   POST /api/employee/facilityReport/house/:houseId/create
+ */
+router.post('/house/:houseId/create', createFacilityReport);
+
+/**
+ * @desc    Update the facility report
+ * @route   PUT /api/employee/facilityReport/:facilityReportId/update
+ */
+router.put('/:facilityReportId/update', updateFacilityReport);
+
+/**
+ * @desc    Delete the facility report
+ * @route   DELETE /api/employee/facilityReport/:facilityReportId/delete
+ */
+router.delete('/:facilityReportId/delete', deleteFacilityReport);
+
+/**
+ * @desc    Comment on their facility report
+ * @route   POST /api/employee/facilityReport/:facilityReportId/comments
+ */
+router.post('/:facilityReportId/comments', addCommentOnFacilityReport);
+
+/**
+ * @desc    Update comment on the facility report
+ * @route   PUT /api/employee/facilityReport/:facilityReportId/comments/:commentId
+ */
+router.put('/:facilityReportId/comments/:commentId', updateCommentOnFacilityReport);
+
+export default router;


### PR DESCRIPTION
<h1>Description</h1>
I created the necessary API routes related to the Facility Report database.

Here are the following routes I've created! They are for the Housing Page!

<h1>Routes</h1>

1. Find all facility reports submitted by the current user for a specific house
- Route: (GET) /api/employee/facilityReport/house/:houseId

2. Create a facility report
- Route: (POST) /api/employee/facilityReport/house/:houseId/create
- Authorization: ONLY the residents of the house can create the facility report.

3. Update an existing facility report
- Route: (PUT) /api/employee/facilityReport/:facilityReportId/update
- Authorization: ONLY the creator of the facility report can edit.

4. Close the facility report
- Route: (PATCH) /api/employee/facilityReport/:facilityReportId/close
- Authorization: ONLY the creator of the facility report can close.

5. Delete an existing facility report
- Route: (DELETE) /api/employee/facilityReport/:facilityReportId/delete
- Authorization: ONLY the creator of the facility report can delete.

6. Comment on their facility report
- Route (POST) /api/employee/facilityReport/:facilityReportId/comments
- Authorization: ONLY the creator of the facility report can comment.

7. Update their comment 
- Route (PUT) /api/employee/facilityReport/:facilityReportId/comments/:commentId
- Authorization: ONLY the creator of the facility report can update their comments.

<h1>Additional Notes</h1>
I am AWARE that the HR can do some of these things like commenting on a facility report.

For the changes I've made in the app.js, note that these routes are specifically for employees only.
Hence, these authorizations are focused primarily on employees, not the HR.